### PR TITLE
Added USB device info for TP-LINK Archer T4U

### DIFF
--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -297,6 +297,7 @@ static struct usb_device_id rtw_usb_id_tbl[] ={
 	{USB_DEVICE(0x07B8, 0x8812),.driver_info = RTL8812}, /* Abocom - Abocom */
 	{USB_DEVICE(0x2001, 0x3315),.driver_info = RTL8812}, /* D-Link - Cameo */
 	{USB_DEVICE(0x2001, 0x3316),.driver_info = RTL8812}, /* D-Link - Cameo */
+	{USB_DEVICE(0x2357, 0x0101),.driver_info = RTL8812}, /* TP-Link - TP-Link */
 #endif
 
 #ifdef CONFIG_RTL8821A


### PR DESCRIPTION
Thanks for consolidating those patches and sharing your original work. Your updated driver works perfectly for me with this small addition to recognise my TP-LINK Archer T4U.

https://wikidevi.com/wiki/TP-LINK_Archer_T4U