### PR TITLE
Moved CONFIG_RTL8821AU variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1564,11 +1564,11 @@ ifeq ($(CONFIG_RTL8821A), y)
 $(MODULE_NAME)-$(CONFIG_MP_INCLUDED)+= core/rtw_bt_mp.o
 endif
 
+export CONFIG_RTL8821AU = m
+
 obj-$(CONFIG_RTL8821AU) := $(MODULE_NAME).o
 
 else
-
-export CONFIG_RTL8821AU = m
 
 all: modules
 

--- a/Makefile
+++ b/Makefile
@@ -1510,6 +1510,8 @@ ifneq ($(USER_MODULE_NAME),)
 MODULE_NAME := $(USER_MODULE_NAME)
 endif
 
+export CONFIG_RTL8821AU = m
+
 ifneq ($(KERNELRELEASE),)
 
 rtk_core :=	core/rtw_cmd.o \
@@ -1563,8 +1565,6 @@ endif
 ifeq ($(CONFIG_RTL8821A), y)
 $(MODULE_NAME)-$(CONFIG_MP_INCLUDED)+= core/rtw_bt_mp.o
 endif
-
-export CONFIG_RTL8821AU = m
 
 obj-$(CONFIG_RTL8821AU) := $(MODULE_NAME).o
 


### PR DESCRIPTION
I've moved the CONFIG_RTL8821AU variable to be above where it is referenced. Before this change the CONFIG_RTL8821AU variable was below where it was being referenced causing the build to fail when KERNELRELEASE was defined on the make line.
