### PR TITLE
Allow to set channel when in monitor mode

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -4573,11 +4573,11 @@ static int	cfg80211_rtw_set_channel(struct wiphy *wiphy
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))
 static int	cfg80211_rtw_set_monitor_channel(struct wiphy *wiphy, struct cfg80211_chan_def *chandef)
 {
-    struct ieee80211_channel *chan = (struct ieee80211_channel *) chandef->chan;
+	struct ieee80211_channel *chan = (struct ieee80211_channel *) chandef->chan;
 	int chan_target = (u8) ieee80211_frequency_to_channel(chan->center_freq);
 	int chan_offset = HAL_PRIME_CHNL_OFFSET_DONT_CARE;
 	int chan_width = CHANNEL_WIDTH_20;
-    enum nl80211_channel_type channel_type = cfg80211_get_chandef_type(chandef);
+	enum nl80211_channel_type channel_type = cfg80211_get_chandef_type(chandef);
 	_adapter *padapter = wiphy_to_adapter(wiphy);
 
 	switch (channel_type) {
@@ -6532,9 +6532,9 @@ static struct cfg80211_ops rtw_cfg80211_ops = {
 	#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 6, 0))
 	.set_channel = cfg80211_rtw_set_channel,
 	#endif
-    #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))
-    .set_monitor_channel = cfg80211_rtw_set_monitor_channel,
-    #endif
+	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))
+	.set_monitor_channel = cfg80211_rtw_set_monitor_channel,
+	#endif
 	//.auth = cfg80211_rtw_auth,
 	//.assoc = cfg80211_rtw_assoc,	
 #endif //CONFIG_AP_MODE

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -4570,6 +4570,42 @@ static int	cfg80211_rtw_set_channel(struct wiphy *wiphy
 	return 0;
 }
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))
+static int	cfg80211_rtw_set_monitor_channel(struct wiphy *wiphy, struct cfg80211_chan_def *chandef)
+{
+    struct ieee80211_channel *chan = (struct ieee80211_channel *) chandef->chan;
+	int chan_target = (u8) ieee80211_frequency_to_channel(chan->center_freq);
+	int chan_offset = HAL_PRIME_CHNL_OFFSET_DONT_CARE;
+	int chan_width = CHANNEL_WIDTH_20;
+    enum nl80211_channel_type channel_type = cfg80211_get_chandef_type(chandef);
+	_adapter *padapter = wiphy_to_adapter(wiphy);
+
+	switch (channel_type) {
+	case NL80211_CHAN_NO_HT:
+	case NL80211_CHAN_HT20:
+		chan_width = CHANNEL_WIDTH_20;
+		chan_offset = HAL_PRIME_CHNL_OFFSET_DONT_CARE;
+		break;
+	case NL80211_CHAN_HT40MINUS:
+		chan_width = CHANNEL_WIDTH_40;
+		chan_offset = HAL_PRIME_CHNL_OFFSET_UPPER;
+		break;
+	case NL80211_CHAN_HT40PLUS:
+		chan_width = CHANNEL_WIDTH_40;
+		chan_offset = HAL_PRIME_CHNL_OFFSET_LOWER;
+		break;
+	default:
+		chan_width = CHANNEL_WIDTH_20;
+		chan_offset = HAL_PRIME_CHNL_OFFSET_DONT_CARE;
+		break;
+	}
+
+	set_channel_bwmode(padapter, chan_target, chan_offset, chan_width);
+	DBG_871X("%s : %d", __func__, chan_target);
+	return 0;
+}
+#endif /* (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)) */
+
 static int	cfg80211_rtw_auth(struct wiphy *wiphy, struct net_device *ndev,
 			struct cfg80211_auth_request *req)
 {
@@ -6496,6 +6532,9 @@ static struct cfg80211_ops rtw_cfg80211_ops = {
 	#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 6, 0))
 	.set_channel = cfg80211_rtw_set_channel,
 	#endif
+    #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0))
+    .set_monitor_channel = cfg80211_rtw_set_monitor_channel,
+    #endif
 	//.auth = cfg80211_rtw_auth,
 	//.assoc = cfg80211_rtw_assoc,	
 #endif //CONFIG_AP_MODE


### PR DESCRIPTION
The original driver (4.3.22-beta) has monitor mode, but won't allow to change the channel currently being monitored. When using channel hoping mode on airodump-ng and Kismet the netlink returns "operation not supported error".
The changes i`m submitting allow the driver to change channels when in monitor mode (when kernel version is >= 3.8), allowing channel hoping to function correctly.
Tested modifications with Kismet and airodump-ng and channels are now changed correctly.

https://www.kernel.org/doc/htmldocs/80211/API-struct-cfg80211-ops.html
