### PR TITLE
is_compat_task is on way out on x86 - change to in_compat_syscall

### DIFF
--- a/os_dep/linux/ioctl_linux.c
+++ b/os_dep/linux/ioctl_linux.c
@@ -15616,7 +15616,11 @@ static int rtw_ioctl_standard_wext_private(struct net_device *dev, struct ifreq 
 static int rtw_ioctl_wext_private(struct net_device *dev, struct ifreq *rq)
 {
 #ifdef CONFIG_COMPAT
+#ifdef in_compat_syscall
+    if(in_compat_syscall())
+#else
 	if(is_compat_task())
+#endif
 		return rtw_ioctl_compat_wext_private( dev, rq );
 	else
 #endif // CONFIG_COMPAT

--- a/os_dep/linux/rtw_android.c
+++ b/os_dep/linux/rtw_android.c
@@ -575,7 +575,12 @@ int rtw_android_priv_cmd(struct net_device *net, struct ifreq *ifr, int cmd)
 		goto exit;
 	}
 #ifdef CONFIG_COMPAT
-	if (is_compat_task()) {
+#ifdef in_compat_syscall
+    if (in_compat_syscall())
+#else
+	if (is_compat_task())
+#endif
+	{
 		/* User space is 32-bit, use compat ioctl */
 		compat_android_wifi_priv_cmd compat_priv_cmd;
 


### PR DESCRIPTION
Tested on x86_64 with kernel 4.6.2
