### PR TITLE
Add support for kernels >= 4.7

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -2013,6 +2013,12 @@ void rtw_cfg80211_indicate_scan_done(_adapter *adapter, bool aborted)
 {
 	struct rtw_wdev_priv *pwdev_priv = adapter_wdev_data(adapter);
 	_irqL	irqL;
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 7, 0))
+	struct cfg80211_scan_info info;
+
+	memset(&info, 0, sizeof(info));
+	info.aborted = aborted;
+#endif // (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 7, 0))
 
 	_enter_critical_bh(&pwdev_priv->scan_req_lock, &irqL);
 	if (pwdev_priv->scan_request != NULL) {
@@ -2027,7 +2033,11 @@ void rtw_cfg80211_indicate_scan_done(_adapter *adapter, bool aborted)
 		}
 		else
 		{
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 7, 0))
+			cfg80211_scan_done(pwdev_priv->scan_request, &info);
+#else // (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 7, 0))
 			cfg80211_scan_done(pwdev_priv->scan_request, aborted);
+#endif // (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 7, 0))
 		}
 
 		pwdev_priv->scan_request = NULL;


### PR DESCRIPTION
This patch fix compilation failure caused by modification of
cfg80211_scan_done() prototype.

Signed-off-by: Masashi Honma masashi.honma@gmail.com
