### PR TITLE
change i.mx6 platform data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1087,12 +1087,14 @@ endif
 
 ifeq ($(CONFIG_PLATFORM_FS_MX61), y)
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
 ARCH := arm
-CROSS_COMPILE := /home/share/CusEnv/FreeScale/arm-eabi-4.4.3/bin/arm-eabi-
-KSRC ?= /home/share/CusEnv/FreeScale/FS_kernel_env
+CROSS_COMPILE ?=
+KVER ?= $(shell uname -r)
+KSRC := /lib/modules/$(KVER)/build
+MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/
+INSTALL_PREFIX :=
 endif
-
-
 
 ifeq ($(CONFIG_PLATFORM_ACTIONS_ATJ227X), y)
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN -DCONFIG_PLATFORM_ACTIONS_ATJ227X


### PR DESCRIPTION
I noticed that the driver wouldn't compile anymore since armbian upgrade to 4.9.x as stable.
The makefile didn't pick up the architecture properly. There was also a kinda lost mx61 platform definition seemingly prepared for local usage of one dev - i modified to work universally and make the driver compile on my cubox-i again.

This enables universal compiling on freescale i-mx6 machines like cubox-i with new kernel versions (testet 4.9.12)