### PR TITLE
Update ioctl_cfg80211.c for kernel 4.11.9

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -3879,7 +3879,13 @@ static int rtw_cfg80211_add_monitor_if(_adapter *padapter, char *name,
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,1,0))
 	mon_ndev->name_assign_type = name_assign_type;
 #endif
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,11,9))
+	mon_ndev->needs_free_netdev = false;
+	mon_ndev->priv_destructor = rtw_ndev_destructor;
+#else
 	mon_ndev->destructor = rtw_ndev_destructor;
+#endif
 	
 #if (LINUX_VERSION_CODE>=KERNEL_VERSION(2,6,29))
 	mon_ndev->netdev_ops = &rtw_cfg80211_monitor_if_ops;


### PR DESCRIPTION
struct net_device's priv_destructor replaced destructor at kernel v4.11.9
ref : https://elixir.free-electrons.com/linux/v4.11.9/source/include/linux/netdevice.h